### PR TITLE
setup.py: list flatex module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ setup(
     install_requires = [
         'Click',
         ],
+    py_modules=["flatex"],
     entry_points='''
     [console_scripts]
     flatex=flatex:main


### PR DESCRIPTION
Thanks for the script. This PR lists the main module `flatex` in `setup.py` such that the `build` command from `setup.py` considers it and therefore adds it to an install with `python setup.py install`.

With this change, one could consider updating the installation instructions and remove the editable switch.

Thanks for your consideration.