### PR TITLE
update flatex for fixing  --include_bbl issue when include bib files …

### DIFF
--- a/flatex.py
+++ b/flatex.py
@@ -37,7 +37,7 @@ def combine_path(base_path, relative_ref):
         return os.path.abspath(relative_ref) + '.tex'
 
 
-def expand_file(base_file, current_path, include_bbl, noline, nocomment):
+def expand_file(start_base_file, base_file, current_path, include_bbl, noline, nocomment):
     """
     Recursively-defined function that takes as input a file and returns it
     with all the inputs replaced with the contents of the referenced file.
@@ -47,13 +47,13 @@ def expand_file(base_file, current_path, include_bbl, noline, nocomment):
     for line in f:
         if is_input(line):
             new_base_file = combine_path(current_path, get_input(line))
-            output_lines += expand_file(new_base_file, current_path, include_bbl, noline, nocomment)
+            output_lines += expand_file(start_base_file, new_base_file, current_path, include_bbl, noline, nocomment)
             if noline:
                 pass
             else:
                 output_lines.append('\n')  # add a new line after each file input
         elif include_bbl and line.startswith("\\bibliography") and (not line.startswith("\\bibliographystyle")):
-            output_lines += bbl_file(base_file)
+            output_lines += bbl_file(start_base_file)
         elif nocomment and len(line.lstrip()) > 0 and line.lstrip()[0] == "%":
             pass
         else:
@@ -62,11 +62,11 @@ def expand_file(base_file, current_path, include_bbl, noline, nocomment):
     return output_lines
 
 
-def bbl_file(base_file):
+def bbl_file(start_base_file):
     """
     Return content of associated .bbl file
     """
-    bbl_path = os.path.abspath(os.path.splitext(base_file)[0]) + '.bbl'
+    bbl_path = os.path.abspath(os.path.splitext(start_base_file)[0]) + '.bbl'
     return open(bbl_path).readlines()
 
 
@@ -75,17 +75,24 @@ def bbl_file(base_file):
 @click.argument('output_file', type = click.Path())
 @click.option('--include_bbl/--no_bbl', default=False)
 @click.option("--noline", is_flag = True)
-@click.option("--nocomment", is_flag = True, help="remove any line that is a comment (this will preserve comments"
-                                                  "at the same line as the text)")
-def main(base_file, output_file, include_bbl = False, noline = False, nocomment=False):
+@click.option("--nocomment", is_flag = True
+              , help="""remove any line that is a comment 
+                    (this will preserve comments"
+                        "at the same line as the text)""")
+def main(base_file, output_file, include_bbl=False, noline=False, nocomment=False):
     
     """
     This "flattens" a LaTeX document by replacing all \input{X} lines w/ the
     text actually contained in X. See associated README.md for details.
     """
     current_path = os.path.split(base_file)[0]
-    g = open(output_file, "w",encoding='utf-8')
-    g.write(''.join(expand_file(base_file, current_path, include_bbl, noline, nocomment)))
+    g = open(output_file, "w", encoding='utf-8')
+    lines = expand_file(base_file, base_file, current_path, include_bbl,
+                        noline, nocomment)
+    content = ''.join(lines)
+    g.write(content)
     g.close()
     return None
+
+
 


### PR DESCRIPTION
…is not main file

Previous code works when bibliography command is used in the main file.
But if you use another file for bibliography commands, it gives error.
For  example, below command has bibliography commands.

\input{bib-files}

Previous code gives error saying that I could not find bib-files.bbl file.

I also changed function calls to be in separate lines in main function for easy debugging 
